### PR TITLE
test: check that we are up and running

### DIFF
--- a/src/test/java/se/digg/wallet/provider/ApplicationTests.java
+++ b/src/test/java/se/digg/wallet/provider/ApplicationTests.java
@@ -4,11 +4,33 @@
 package se.digg.wallet.provider;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class ApplicationTests {
 
+  @Autowired
+  private MockMvc mvc;
+
   @Test
-  void contextLoads() {}
+  void isHealthy() throws Exception {
+    mvc.perform(get("/actuator/health")
+        .accept(MediaType.APPLICATION_JSON))
+        .andDo(log())
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.status", is("UP")));
+  }
 }


### PR DESCRIPTION
This change set adds a simple test for the health endpoint

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
