### PR TITLE
feat: fail build on Java formatting issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@ SPDX-License-Identifier: EUPL-1.2
         <executions>
           <execution>
             <goals>
-              <goal>format</goal>
+              <goal>validate</goal>
             </goals>
             <phase>verify</phase>
           </execution>


### PR DESCRIPTION
Without this change the build will format the Java files but not report any errors. This could lead to malformatted files being accepted onto main.

To apply the automated formatting we can use the following command:

	mvn formatter:format

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
