### PR TITLE
feat: fail on unversioned changes

### DIFF
--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -128,6 +128,22 @@ verify() {
   printf '\n\n'
 }
 
+version_control() {
+  print_header 'VERSION CONTROL'
+  git status
+  test -z "$(git status --porcelain | awk '{$1=$1};1')"
+  store_exit_code "$?" "Version control" \
+    "${MISSING} ${RED}Some changes are not under version control! \
+This can happen if
+
+  1. You forgot to version control your changes
+  2. A linter automatically fixed a problem or reformatted the code.
+
+Please accept or discard any outstanding changes and try again.${NC}\n\n" \
+    "${GREEN}${CHECKMARK}${CHECKMARK} Version control check passed${NC}\n"
+  printf '\n\n'
+}
+
 # coverage() {
 #   print_header 'COVERAGE (JACOCO)'
 #   mvn clean verify "${MAVEN_CLI_OPTS[@]}" -Dcoverage -Djacoco.fail=true
@@ -166,5 +182,6 @@ lint
 commit
 verify
 license
+version_control
 
 check_exit_codes


### PR DESCRIPTION
This change adds a check to the code_quality.sh script that looks for unversioned changes. If there are any unversioned changes, the check fails and the user is prompted to accept or discard the outstanding changes.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
