### PR TITLE
Test/fail on formatting errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@ SPDX-License-Identifier: EUPL-1.2
   <properties>
     <java.version>21</java.version>
     <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>
-    <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <checkstyle.version>12.3.1</checkstyle.version>
     <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,10 +145,11 @@ SPDX-License-Identifier: EUPL-1.2
         </configuration>
         <executions>
           <execution>
+            <id>validate</id>
+            <phase>validate</phase>
             <goals>
-              <goal>format</goal>
+              <goal>validate</goal>
             </goals>
-            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>

--- a/src/test/java/se/digg/wallet/provider/application/controller/WalletUnitAttestationControllerTest.java
+++ b/src/test/java/se/digg/wallet/provider/application/controller/WalletUnitAttestationControllerTest.java
@@ -98,62 +98,62 @@ class WalletUnitAttestationControllerTest {
 
   @Test
   void assertThatPostWalletUnitAttestationV2_givenPublicKeyAndEmptyNonce_shouldReturnOk()
-          throws Exception {
+      throws Exception {
     String expectedJwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJEaWdnIn0.test";
     when(service.createWalletUnitAttestationV2(anyString(), anyString()))
-            .thenReturn(SignedJWT.parse(expectedJwt));
+        .thenReturn(SignedJWT.parse(expectedJwt));
 
     String jwk =
-            """
-                {
-                    "kty": "EC",
-                    "use": "sig",
-                    "crv": "P-256",
-                    "x": "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
-                    "y": "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
-                }
-                """;
+        """
+            {
+                "kty": "EC",
+                "use": "sig",
+                "crv": "P-256",
+                "x": "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
+                "y": "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
+            }
+            """;
     String nonce = "";
     WalletUnitAttestationDtoV2 input =
-            new WalletUnitAttestationDtoV2(UUID.randomUUID(), jwk, nonce);
+        new WalletUnitAttestationDtoV2(UUID.randomUUID(), jwk, nonce);
 
     mockMvc
-            .perform(
-                    post(WUA_V2_URL)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(asJson(input)))
-            .andExpect(status().isOk())
-            .andExpect(content().string(expectedJwt));
+        .perform(
+            post(WUA_V2_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJson(input)))
+        .andExpect(status().isOk())
+        .andExpect(content().string(expectedJwt));
   }
 
   @Test
   void assertThatPostWalletUnitAttestationV2_givenPublicKeyAndNullNonce_shouldReturnOk()
-          throws Exception {
+      throws Exception {
     String expectedJwt = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJEaWdnIn0.test";
     when(service.createWalletUnitAttestationV2(anyString(), eq(null)))
-            .thenReturn(SignedJWT.parse(expectedJwt));
+        .thenReturn(SignedJWT.parse(expectedJwt));
 
     String jwk =
-            """
-                {
-                    "kty": "EC",
-                    "use": "sig",
-                    "crv": "P-256",
-                    "x": "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
-                    "y": "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
-                }
-                """;
+        """
+            {
+                "kty": "EC",
+                "use": "sig",
+                "crv": "P-256",
+                "x": "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
+                "y": "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
+            }
+            """;
 
     WalletUnitAttestationDtoV2 input =
-            new WalletUnitAttestationDtoV2(UUID.randomUUID(), jwk, null);
+        new WalletUnitAttestationDtoV2(UUID.randomUUID(), jwk, null);
 
     mockMvc
-            .perform(
-                    post(WUA_V2_URL)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(asJson(input)))
-            .andExpect(status().isOk())
-            .andExpect(content().string(expectedJwt));
+        .perform(
+            post(WUA_V2_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJson(input)))
+        .andExpect(status().isOk())
+        .andExpect(content().string(expectedJwt));
   }
 
   private String asJson(Object input) throws JsonProcessingException {


### PR DESCRIPTION
This changeset ensures that formatting mistakes are detected instead of silently ignored and is similiar to what we have in wallet-ecosystem. To run the formatter, you can still use the command below:

	mvn net.revelc.code.formatter:formatter-maven-plugin:2.29.0:format

We also fix the formatting of existing files to comply with our style to avoid having a broken build. 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
