### PR TITLE
fix: add no-op version control linter

### DIFF
--- a/justfile
+++ b/justfile
@@ -89,6 +89,10 @@ verify: _ensure-devtools check-tools
 lint-all: _ensure-devtools
     @{{devtools_dir}}/scripts/verify.sh
 
+# Validate version control
+[group('lint')]
+lint-version-control:
+
 # Validate commit messages
 [group('lint')]
 lint-commits:


### PR DESCRIPTION
This fixes `just verify` and `just lint-all` after update to devbase-check v0.4.1.

See: https://github.com/diggsweden/devbase-check/releases/tag/v0.4.1

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
