### PR TITLE
fix: bump reusable integration workflow

### DIFF
--- a/.github/workflows/ecosystem-integration.yml
+++ b/.github/workflows/ecosystem-integration.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
   integration-test:
     # Use the specific commit hash from the wallet-ecosystem repository for stability.
-    # This hash corresponds to the merge of the reusable integration workflow into main.
-    uses: diggsweden/wallet-ecosystem/.github/workflows/reusable-integration.yml@758cef4f7d799a0ec8577d9bffaa28044210f1f3
+    uses: diggsweden/wallet-ecosystem/.github/workflows/reusable-integration.yml@c6548a93878f74cae1aaf756dd2f8efcda102b88
     with:
+      ecosystem-ref: 'c6548a93878f74cae1aaf756dd2f8efcda102b88'
       service-name: wallet-provider
       service-repo: ${{ github.repository }}
       service-ref: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/ecosystem-integration.yml
+++ b/.github/workflows/ecosystem-integration.yml
@@ -23,7 +23,6 @@ jobs:
     # Use the specific commit hash from the wallet-ecosystem repository for stability.
     uses: diggsweden/wallet-ecosystem/.github/workflows/reusable-integration.yml@c6548a93878f74cae1aaf756dd2f8efcda102b88
     with:
-      ecosystem-ref: 'c6548a93878f74cae1aaf756dd2f8efcda102b88'
       service-name: wallet-provider
       service-repo: ${{ github.repository }}
       service-ref: ${{ github.event.pull_request.head.sha || github.ref }}


### PR DESCRIPTION
Here we change to a version of the reusable integration workflow that fixes an issue with the ecosystem startup.

See: https://github.com/diggsweden/wallet-ecosystem/commit/ee9d38bdb839e583d770e513a5e9a51b0a0342de

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
