### PR TITLE
fix: use main version of reusable integration script

### DIFF
--- a/.github/workflows/ecosystem-integration.yml
+++ b/.github/workflows/ecosystem-integration.yml
@@ -20,8 +20,7 @@ concurrency:
 
 jobs:
   integration-test:
-    # Use the specific commit hash from the wallet-ecosystem repository for stability.
-    uses: diggsweden/wallet-ecosystem/.github/workflows/reusable-integration.yml@e2531e89aa1147a11cc04550e24f7a8fafa9d2d5
+    uses: diggsweden/wallet-ecosystem/.github/workflows/reusable-integration.yml@main
     with:
       service-name: wallet-provider
       service-repo: ${{ github.repository }}


### PR DESCRIPTION
This change ensures that the version of the workflow script matches the version of wallet-ecosystem we want to test.

We want to verify that the changes to our service is compatible with what is released into the ecosystem. This is represented by the main branch of wallet-ecosystem, and this is by default what is checked out by the reusable integration test script.

Since the reusable integration script is also defined in wallet-ecosystem, it makes sense to use the version available on the main branch. For instance, this will avoid failures where wallet-ecosystem has started using a newer version of Java for running tests, but we are using an older version of the workflow file that prepares an environment with an older Java version.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
