### PR TITLE
build(deps): bump tomcat-embed-core to version 11.0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,13 @@ SPDX-License-Identifier: EUPL-1.2
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+    <!-- Avoid security vulnerabilities in 11.0.21 -->
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>11.0.22</version>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>


### PR DESCRIPTION
This avoids using version 11.0.21 which has knows security vulnerabilities.

See: https://github.com/advisories/GHSA-r29c-68gh-xp6x
See: https://github.com/advisories/GHSA-h6fc-48rj-7qqh
See: https://github.com/advisories/GHSA-5m62-pw8w-7w9f

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
