### PR TITLE
feat: set initial code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: EUPL-1.2
 
-# Global code owners - to be updated with actual maintainers
+# Global code owners
+* @ChristofferKillander @danneleaf @eric-thelin @johan-forsman @mjsaa @shir-digg


### PR DESCRIPTION
Here we set the code owners to the actual development team.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
