### PR TITLE
chore: remove suffix with repo name from copyright text

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 # SPDX-License-Identifier: EUPL-1.2
 
 # Stage 1: Build stage

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-provider
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-provider
+SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 
 SPDX-License-Identifier: EUPL-1.2
 -->

--- a/development/settings.xml
+++ b/development/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 
 SPDX-License-Identifier: CC0-1.0
 -->

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-provider
+SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 SPDX-License-Identifier: EUPL-1.2

--- a/package.json.license
+++ b/package.json.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-provider
+SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 SPDX-License-Identifier: EUPL-1.2

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-provider
+SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 
 SPDX-License-Identifier: EUPL-1.2
 -->

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/src/main/java/se/digg/wallet/provider/Application.java
+++ b/src/main/java/se/digg/wallet/provider/Application.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-provider
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/main/java/se/digg/wallet/provider/application/config/LoggingContextFilter.java
+++ b/src/main/java/se/digg/wallet/provider/application/config/LoggingContextFilter.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-backend-reference
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/main/java/se/digg/wallet/provider/application/config/WalletRuntimeException.java
+++ b/src/main/java/se/digg/wallet/provider/application/config/WalletRuntimeException.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-backend-reference
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/main/java/se/digg/wallet/provider/application/config/WuaKeystoreProperties.java
+++ b/src/main/java/se/digg/wallet/provider/application/config/WuaKeystoreProperties.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/main/java/se/digg/wallet/provider/application/controller/WalletUnitAttestationController.java
+++ b/src/main/java/se/digg/wallet/provider/application/controller/WalletUnitAttestationController.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-backend-reference
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/main/java/se/digg/wallet/provider/application/model/WalletUnitAttestationDto.java
+++ b/src/main/java/se/digg/wallet/provider/application/model/WalletUnitAttestationDto.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-backend-reference
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/main/java/se/digg/wallet/provider/application/service/WalletUnitAttestationService.java
+++ b/src/main/java/se/digg/wallet/provider/application/service/WalletUnitAttestationService.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-backend-reference
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 # SPDX-License-Identifier: EUPL-1.2
 
 wua:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 # SPDX-License-Identifier: EUPL-1.2
 
 server:

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 SPDX-License-Identifier: EUPL-1.2
 -->
 <configuration>

--- a/src/test/java/se/digg/wallet/provider/ActuatorHealthTest.java
+++ b/src/test/java/se/digg/wallet/provider/ActuatorHealthTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/test/java/se/digg/wallet/provider/ApplicationTests.java
+++ b/src/test/java/se/digg/wallet/provider/ApplicationTests.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/test/java/se/digg/wallet/provider/application/config/LoggingFilterTest.java
+++ b/src/test/java/se/digg/wallet/provider/application/config/LoggingFilterTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/test/java/se/digg/wallet/provider/application/config/WuaKeystorePropertiesTest.java
+++ b/src/test/java/se/digg/wallet/provider/application/config/WuaKeystorePropertiesTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/test/java/se/digg/wallet/provider/application/controller/WalletUnitAttestationControllerTest.java
+++ b/src/test/java/se/digg/wallet/provider/application/controller/WalletUnitAttestationControllerTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/test/java/se/digg/wallet/provider/application/service/WalletUnitAttestationServiceTest.java
+++ b/src/test/java/se/digg/wallet/provider/application/service/WalletUnitAttestationServiceTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 //
 // SPDX-License-Identifier: EUPL-1.2
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/src/test/resources/certificates/wallet-provider.p12.license
+++ b/src/test/resources/certificates/wallet-provider.p12.license
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government/wallet-provider
+SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
 SPDX-License-Identifier: EUPL-1.2


### PR DESCRIPTION
# Pull Request Description

Vi tar bort suffix med reponamnet från copyright text i filer då vi anser att rätt sätt är att endast ha myndighetens namn i texten, inte fil eller projektnamn etc. Uppdaterar också till nuvarande år där det tidigare var 2025

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
