### PR TITLE
chore: use 'tools' option for extracting Container layers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -27,7 +27,10 @@ COPY src ./src
 
 # Build the application (skip checkstyle in Docker build)
 RUN ./mvnw clean package -DskipTests -Dcheckstyle.skip -Dformatter.skip -B && \
-    java -Djarmode=layertools -jar target/*.jar extract
+    java -Djarmode=tools -jar target/*.jar extract --layers --destination /app/target/layers
+
+# Ensure we have a consistent name to use as an entrypoint argument
+RUN mv /app/target/layers/application/*.jar /app/target/layers/application/application.jar
 
 # Stage 2: Runtime stage
 FROM cgr.dev/chainguard/jre:latest@sha256:867928b6194d1feaf6803dc99e055f21f9de99258776e4060a86e483d6a472fb AS runtime
@@ -38,12 +41,12 @@ LABEL description="Wallet Provider"
 WORKDIR /app
 
 # Copy Spring Boot layers from builder stage (nonroot user: 65532)
-COPY --from=builder --chown=65532:65532 /app/dependencies/ ./
-COPY --from=builder --chown=65532:65532 /app/spring-boot-loader/ ./
-COPY --from=builder --chown=65532:65532 /app/snapshot-dependencies/ ./
-COPY --from=builder --chown=65532:65532 /app/application/ ./
+COPY --from=builder --chown=65532:65532 /app/target/layers/dependencies/ ./
+COPY --from=builder --chown=65532:65532 /app/target/layers/spring-boot-loader/ ./
+COPY --from=builder --chown=65532:65532 /app/target/layers/snapshot-dependencies/ ./
+COPY --from=builder --chown=65532:65532 /app/target/layers/application/ ./
 
 EXPOSE 8080
 
 # JVM options are set directly in ENTRYPOINT since distroless has no shell
-ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=75.0", "-XX:+UseG1GC", "-XX:+UseStringDeduplication", "-Djava.security.egd=file:/dev/./urandom", "-Dfile.encoding=UTF-8", "org.springframework.boot.loader.launch.JarLauncher"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=75.0", "-XX:+UseG1GC", "-XX:+UseStringDeduplication", "-Djava.security.egd=file:/dev/./urandom", "-Dfile.encoding=UTF-8", "-jar", "application.jar"]


### PR DESCRIPTION
The 'layertools' option is no longer available in Spring Boot version 4.1, so we need to migrate to the newer 'tools' option prior to the Spring Boot upgrade.

This is a prerequisite for #97.

See: https://docs.spring.io/spring-boot/reference/packaging/container-images/dockerfiles.html
See: https://github.com/spring-projects/spring-boot/commit/da56bfea6ee74b5fed348d20eac4c8b87a2e23ab

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
