### PR TITLE
fix: wua response content type

### DIFF
--- a/src/main/resources/static/wallet-provider-openapi-v0.yaml
+++ b/src/main/resources/static/wallet-provider-openapi-v0.yaml
@@ -52,7 +52,7 @@ paths:
         "200":
           description: Successfully created Wallet Unit Attestation
           content:
-            application/json:
+            text/plain:
               schema:
                 $ref: '#/components/schemas/WalletUnitAttestationResponse'
         "400":


### PR DESCRIPTION
# Pull Request Description

Change response content-type in API-spec for POST /wallet-unit-attestation to text/plain.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
